### PR TITLE
allow multiple source accounts for payment operations

### DIFF
--- a/microstellar.go
+++ b/microstellar.go
@@ -415,6 +415,7 @@ func (ms *MicroStellar) Pay(sourceAddressOrSeed string, targetAddress string, am
 		}
 	}
 
+	paymentMuts = append(paymentMuts, build.SourceAccount{AddressOrSeed: sourceAddressOrSeed})
 	tx.Build(sourceAccount(sourceAddressOrSeed), build.Payment(paymentMuts...))
 	return ms.signAndSubmit(tx, sourceAddressOrSeed)
 }


### PR DESCRIPTION
Always add the SourceAccount to the `paymentMuts` so we can submit a transaction that includes operations from different source accounts (this is different from the multisig use-case outlined in the readme).

Sample Usage:
```
ms.Start(a.Address, microstellar.Opts().WithSigner(a.Seed).WithSigner(b.Seed))
ms.PayNative(a.Address, receiver1.Address, "1.0")
ms.PayNative(b.Address, receiver2.Address, "1.0")
err := ms.Submit()
```

Always including the source account in the `paymentMuts` is safe even if the source account matches the transaction's source account. This should ideally be done for all operations in _microstellar_, but it would be great if you could include this PR for now.